### PR TITLE
feat(message-flags): introduce anon, nocut message flagging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module sanitizetelebot
 
 go 1.22.1
 
-require (
-	github.com/pkg/errors v0.9.1 // indirect
-	gopkg.in/tucnak/telebot.v2 v2.5.0 // indirect
-)
+require gopkg.in/tucnak/telebot.v2 v2.5.0
+
+require github.com/pkg/errors v0.9.1 // indirect

--- a/sanitizetelebot.go
+++ b/sanitizetelebot.go
@@ -42,6 +42,10 @@ func main() {
 	b.Handle(telebot.OnText, func(m *telebot.Message) {
 		username := getUsername(m.Sender)
 
+		if strings.Contains(m.Text, "nocut") {
+			return
+		}
+
 		sanitizedMsg, sanitized, err := sanitizeURL(m.Text)
 		if err != nil {
 			log.Println(err)
@@ -49,7 +53,11 @@ func main() {
 		}
 
 		if sanitized {
-			b.Send(m.Chat, "@"+username+" said: "+sanitizedMsg)
+			if m.FromGroup() && strings.Contains(m.Text, "anon") {
+				b.Send(m.Chat, strings.Replace(sanitizedMsg, "anon", "", 1))
+			} else {
+				b.Send(m.Chat, "@"+username+" said: "+sanitizedMsg)
+			}
 			b.Delete(m)
 		}
 	})
@@ -77,6 +85,7 @@ func main() {
 		}
 	})
 
+	log.Println("starting bot")
 	b.Start()
 }
 


### PR DESCRIPTION
This pull requests introduces two features:
- In groups, appending `anon` to the message will not quote the original author in the bot message.
- If "nocut" is specified, the bot noops. 
